### PR TITLE
chore: add Renovate and pnpm minimumReleaseAge setting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 enable-pre-post-scripts = true
+minimum-release-age=10080

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests", ":pinDevDependencies"],
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "groupName": "devDependencies (non-major)",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Renovate configuration for automated dependency updates with auto-merge for patches and dev dependencies
- Add `minimum-release-age=10080` (7 days) to `.npmrc` to mitigate supply chain attacks by blocking installation of packages released less than 7 days ago

## Test plan
- [ ] Verify Renovate picks up the configuration and creates dependency update PRs
- [ ] Verify `pnpm install` respects the minimum release age setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)